### PR TITLE
Set inViewport to false when element is no longer in viewport

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,11 +57,14 @@ function handleViewport(Component, options) {
       const entry = entries[0] || {};
       const { intersectionRatio } = entry;
       if (intersectionRatio <= 0) {
-        return;
+        this.setState({
+          inViewport: false
+        });
+      } else {
+        this.setState({
+          inViewport: true
+        });
       }
-      this.setState({
-        inViewport: true
-      });
     }
 
     render() {


### PR DESCRIPTION
I'd like to use ```react-in-viewport``` to monitor which elements are displayed to the user for analytics purposes. Thus the app should also know if the elements have been in viewport.  Setting ```inViewport``` to false in ```handleIntersection``` should do the trick. 

Is this feature something that could be included in the package?