### PR TITLE
Fix component update doesn't trigger props change

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Dependencies: [Intersection Observer Polyfills](https://www.npmjs.com/package/in
 
 ## Usages
 
-Wrap your component with handleViewport HOC, you will receive
-1. `inViewport` props indicating the component is in viewport or not.
+Wrap your component with handleViewport HOC, you will receive `inViewport` props indicating the component is in viewport or not.
 
-`handleViewport` HOC accepts three params, the first one is your component and the second param is the option you want to pass to [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+`handleViewport` HOC accepts three params
 
-The third `config` param
-1. `config.disconnectOnLeave { Boolean }` disconnect intersection observer after leave
+1. Component
+1. Options: second param is the option you want to pass to [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+1. Config object:
+ - `disconnectOnLeave { Boolean }` disconnect intersection observer after leave
 
 The HOC preserve `onEnterViewport` and `onLeaveViewport` props as a callback
 
@@ -34,6 +35,7 @@ const Block = (props: { inViewport: boolean }) => {
     </div>
   );
 };
+
 const ViewportBlock = handleViewport(Block, /** options: {}, config: {} **/);
 
 const Component = (props) => (

--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@ Use [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API
 
 Dependencies: [Intersection Observer Polyfills](https://www.npmjs.com/package/intersection-observer)
 
-
 ## Usages
 
-Wrap your component with handleViewport HOC, you will receive `inViewport` props indicating the component is in viewport or not.
+Wrap your component with handleViewport HOC, you will receive
+1. `inViewport` props indicating the component is in viewport or not.
 
-`handleViewport` HOC accepts two params, the first one is your component and the second param is the option you want to pass to [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+`handleViewport` HOC accepts three params, the first one is your component and the second param is the option you want to pass to [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
 
+The third `config` param
+1. `config.disconnectOnLeave { Boolean }` disconnect intersection observer after leave
+
+The HOC preserve `onEnterViewport` and `onLeaveViewport` props as a callback
 
 *NOTE*: Stateless: Need to add `ref={this.props.innerRef}` on your component
 
@@ -30,14 +34,14 @@ const Block = (props: { inViewport: boolean }) => {
     </div>
   );
 };
-const ViewportBlock = handleViewport(Block, /** options: {} **/);
+const ViewportBlock = handleViewport(Block, /** options: {}, config: {} **/);
 
 const Component = (props) => (
   <div>
     <div style={{ height: '100vh' }}>
       <h2>Scroll down to make component in viewport</h2>
     </div>
-    <ViewportBlock />
+    <ViewportBlock onEnterViewport={() => console.log('enter')} onLeaveViewport={() => console.log('leave')} />
   </div>
 ))
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-in-viewport",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Track React component in viewport",
   "author": "Roderick Hsiao <roderickhsiao@gmail.com>",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 
-function handleViewport(Component, options) {
+function handleViewport(Component, options, config = { disconnectOnLeave: false }) {
   class InViewport extends PureComponent {
     constructor(props) {
       super(props);
@@ -16,6 +16,7 @@ function handleViewport(Component, options) {
       this.state = {
         inViewport: false
       };
+      this.intersected = false;
       this.handleIntersection = this.handleIntersection.bind(this);
       this.initIntersectionObserver = this.initIntersectionObserver.bind(this);
     }
@@ -24,6 +25,15 @@ function handleViewport(Component, options) {
       // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
       this.initIntersectionObserver();
       this.startObserver(this.node, this.observer);
+    }
+
+    componentDidUpdate() {
+      // reset observer on update, to fix race condition that when observer init, the element is not in viewport
+      // such as in animation
+      if (!config.disconnectOnLeave && !this.intersected) {
+        this.stopObserver(this.node, this.observer);
+        this.startObserver(this.node, this.observer);
+      }
     }
 
     initIntersectionObserver() {
@@ -54,18 +64,40 @@ function handleViewport(Component, options) {
     }
 
     handleIntersection(entries) {
+      const { onEnterViewport, onLeaveViewport } = this.props;
       const entry = entries[0] || {};
       const { intersectionRatio } = entry;
+      const inViewport = intersectionRatio > 0;
+
+      // enter
+      if (!this.intersected && inViewport) {
+        this.intersected = true;
+        onEnterViewport && onEnterViewport();
+      }
+
+      // leave
+      if (this.intersected && !inViewport) {
+        onLeaveViewport && onLeaveViewport();
+        if (config.disconnectOnLeave) {
+          // disconnect obsever on leave
+          this.observer && this.observer.disconnect();
+        } else {
+          // only reset flag if config.disconnectOnLeave is true,
+          // so that onEnterViewport and onLeaveViewport will only be called once
+          this.intersected = false;
+        }
+      }
 
       this.setState({
-        inViewport: intersectionRatio <= 0 ? false : true
+        inViewport
       });
     }
 
     render() {
+      const { onEnterViewport, onLeaveViewport, ...others } = this.props;
       return (
         <Component
-          {...this.props}
+          {...others}
           inViewport={this.state.inViewport}
           ref={node => {
             this.node = ReactDOM.findDOMNode(node);
@@ -73,6 +105,7 @@ function handleViewport(Component, options) {
           innerRef={node => {
             if (node && !this.node) {
               // handle stateless
+              this.node = ReactDOM.findDOMNode(node);
               this.initIntersectionObserver();
               this.startObserver(ReactDOM.findDOMNode(node), this.observer);
             }


### PR DESCRIPTION
Intersection observer currently only get triggered on certain event, such as `scroll`, `resize` ...

Sometime when react is mounted (such as in transition group) we detect the component is not in viewport, but after a while its programmatically in viewport (when animation finish). Adding reset on componentDidUpdate to catch the issue.

Also support `config.disconnectOnLeave` to disconnect from intersection observer for better performance. 