### PR TITLE
Use isIntersecting to check if element is in viewport

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,8 +76,7 @@ function handleViewport(
     handleIntersection(entries) {
       const { onEnterViewport, onLeaveViewport } = this.props;
       const entry = entries[0] || {};
-      const { intersectionRatio } = entry;
-      const inViewport = intersectionRatio > 0;
+      const inViewport = entry.isIntersecting;
 
       // enter
       if (!this.intersected && inViewport) {


### PR DESCRIPTION
In the IntersectionObserver, for each entry, there is a boolean attribute `isIntersecting` indicating whether an element is in the viewport. Using this rather than `intersectionRatio` fixes an issue with elements sometimes not being registered as having entered the viewport. 