### PR TITLE
Update IsStateless function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,10 @@ import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 
-const isStateless = Component => !Component.prototype.render;
+const isStateless = (Component) => (
+  typeof Component === 'function'
+  && !(Component.prototype && Component.prototype.isReactComponent)
+)
 
 function handleViewport(
   Component,


### PR DESCRIPTION
Functions do not necessarily have a defined prototype in JavaScript, this PR updates the function to use the method described here [https://stackoverflow.com/posts/52211951/revisions](https://stackoverflow.com/questions/41488713/react-how-to-determine-if-component-is-stateless-functional/52211951#52211951)

This issue was breaking our build, and this pull request solves it.