### PR TITLE
Solving installation problem 

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,9 +77,6 @@
   },
   "main": "dist/index.js",
   "module": "dist/es/index.js",
-  "engines": {
-    "npm": "^5.0.0 || ^3.0.0"
-  },
   "bundlesize": [
     {
       "path": "./dist/*.js",


### PR DESCRIPTION
I was experiencing installation problem on a node 8 app

```bash
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for react-in-viewport@1.0.0-alpha.5: wanted: {"npm":"^5.0.0 || ^3.0.0"} (current: {"node":"8.16.0","npm":"6.4.1"})
npm ERR! notsup Not compatible with your version of node/npm: react-in-viewport@1.0.0-alpha.5
npm ERR! notsup Not compatible with your version of node/npm: react-in-viewport@1.0.0-alpha.5
npm ERR! notsup Required: {"npm":"^5.0.0 || ^3.0.0"}
npm ERR! notsup Actual:   {"npm":"6.4.1","node":"8.16.0"}
```

remove the engines specification solved it