### PR TITLE
Issue with composed HOC and forwarding Ref

### DIFF
--- a/src/lib/handleViewport.js
+++ b/src/lib/handleViewport.js
@@ -1,17 +1,16 @@
 // HOC for handleViewport
 import React, { useRef, forwardRef } from 'react';
-import hoistNonReactStatic from 'hoist-non-react-statics';
 import useInViewport from './useInViewport';
 
 const noop = () => {};
 
 function handleViewport(TargetComponent, options, config = { disconnectOnLeave: false }) {
-  const ForwardedRefComponent = forwardRef((props, ref) => {
-    return <TargetComponent {...props} forwardedRef={ref} />;
-  });
-
-  const InViewport = ({ onEnterViewport = noop, onLeaveViewport = noop, ...restProps }) => {
-    const node = useRef();
+  const InViewport = ({
+    onEnterViewport = noop,
+    onLeaveViewport = noop,
+    ...restProps
+  }, ref) => {
+    const node = useRef(ref);
     const { inViewport, enterCount, leaveCount } = useInViewport(
       node,
       options,
@@ -21,9 +20,9 @@ function handleViewport(TargetComponent, options, config = { disconnectOnLeave: 
         onLeaveViewport
       }
     );
-
+    
     return (
-      <ForwardedRefComponent
+      <TargetComponent
         {...restProps}
         inViewport={inViewport}
         enterCount={enterCount}
@@ -33,7 +32,9 @@ function handleViewport(TargetComponent, options, config = { disconnectOnLeave: 
     );
   };
 
-  return hoistNonReactStatic(InViewport, ForwardedRefComponent);
+  const name = TargetComponent.displayName || TargetComponent.name || 'Component';
+  InViewport.displayName = `handleViewport(${name})`;
+  return forwardRef(InViewport);
 }
 
 export default handleViewport;


### PR DESCRIPTION
I had an issue while composing HOC with handleViewport and withRouterAndRef, being a HOC for `react-router-dom` to support forwarding Ref (see issue here https://github.com/ReactTraining/react-router/issues/6056)

```js
import { compose, setDisplayName } from 'recompose';
{...}

export default compose(
  setDisplayName('Component'),
  withRouterAndRef,
  handleViewport,
)(Component);
```

React was complaining about functional component and the way it attempts to access Ref:
```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `RouterAndRefHoc`.
    in InViewport (created by RouterAndRefHoc)
```

So when investigating, I change your HOC to a way I'm used to and it finally worked. I ended not using hoist-non-react-statics. Not sure if it's still needed this way.
Maybe I've misused your package ? React.forwardRef tends to be a challenge sometimes.