### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ export default MySection;
 Alternatively, you can also directly using `useInViewport` hook which takes similar configuration as HOC.
 
 ```js
-import React, { useRef } from 'react;
+import React, { useRef } from 'react';
 import { useInViewport } from 'react-in-viewport';
 
 const MySectionBlock = () => {


### PR DESCRIPTION
resolved "Unterminated string constant" while Importing react in line 158.
syntax written for importing react was wrong. Added quotes to resolve the issue.