### PR TITLE
Allow `null` ref value for `target` argument of `useInViewport`

### DIFF
--- a/src/lib/useInViewport.tsx
+++ b/src/lib/useInViewport.tsx
@@ -8,7 +8,7 @@ import { defaultOptions, defaultConfig, defaultProps } from './constants';
 import type { Config, Props, Options } from './types';
 
 const useInViewport = (
-  target: React.MutableRefObject<HTMLElement>,
+  target: React.RefObject<HTMLElement>,
   options: Options = defaultOptions,
   config : Config = defaultConfig,
   props: Props = defaultProps,


### PR DESCRIPTION
The `target` argument of `useInViewport` is currently typed as `React.RefObject<HTMLElement>`, enforcing that `target.current` will be of type `HTMLElement`. However, it's common to have refs start with an initial value of `null` which is set during render:

```tsx
const Section = () => {
  const ref = useRef<HTMLElement>(null);
  const { enterCount, leaveCount } = useInViewport(ref);

  return (
    <section ref={ref}>
      <div>
        <h1>Hello</h1>
        <p>{`Enter viewport: ${enterCount} times`}</p>
        <p>{`Leave viewport: ${leaveCount} times`}</p>
      </div>
    </section>
  );
};
```

Currently, this causes a type error when passing the possibly null ref to `useInViewport`:

```
Argument of type 'RefObject<HTMLElement>' is not assignable to parameter of type 'MutableRefObject<HTMLElement>'.
  Types of property 'current' are incompatible.
    Type 'HTMLElement | null' is not assignable to type 'HTMLElement'.
      Type 'null' is not assignable to type 'HTMLElement'.ts(2345)
```

This PR fixes this by having `target` be of type `React.RefObject<HTMLElement>` instead, implicitly allowing `null` as a type for `target.current`. This is a fairly common pattern accepting refs in libraries (see [`@use-gesture/react`](https://use-gesture.netlify.app/docs/options/#target-react-only)).

[CodeSandbox reproduction](https://codesandbox.io/s/react-in-viewport-ref-type-error-j3rjsj?file=/src/App.tsx)