### PR TITLE
Enforce that input components accept injected props

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ _NOTE_: Stateless: Need to add `ref={this.props.forwardedRef}` to your component
 
 #### Example of a functional component
 
-```javascript
-import handleViewport from 'react-in-viewport';
+```tsx
+import handleViewport, { type InjectedProps } from 'react-in-viewport';
 
-const Block = (props: { inViewport: boolean }) => {
+const Block = (props: InjectedProps<HTMLDivElement>) => {
   const { inViewport, forwardedRef } = props;
   const color = inViewport ? '#217ac0' : '#ff9800';
   const text = inViewport ? 'In viewport' : 'Not in viewport';

--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -1,10 +1,9 @@
 import { PureComponent } from 'react';
 import { render } from '@testing-library/react';
 import { handleViewport } from '../index';
+import type { InjectedProps } from '../lib/types';
 
-class DemoClass extends PureComponent<{
-  inViewport: boolean;
-}> {
+class DemoClass extends PureComponent<InjectedProps> {
   render() {
     const { inViewport } = this.props;
     return (

--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -1,9 +1,9 @@
 import { PureComponent } from 'react';
 import { render } from '@testing-library/react';
 import { handleViewport } from '../index';
-import type { InjectedProps } from '../lib/types';
+import type { InjectedViewportProps } from '../lib/types';
 
-class DemoClass extends PureComponent<InjectedProps> {
+class DemoClass extends PureComponent<InjectedViewportProps> {
   render() {
     const { inViewport } = this.props;
     return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export default handleViewport;
 export { default as handleViewport } from './lib/handleViewport';
 export { default as useInViewport } from './lib/useInViewport';
 
-export type { InjectedProps } from './lib/types';
+export type { InjectedViewportProps } from './lib/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,5 @@ export const customProps = ['inViewport', 'enterCount', 'leaveCount'];
 export default handleViewport;
 export { default as handleViewport } from './lib/handleViewport';
 export { default as useInViewport } from './lib/useInViewport';
+
+export type { InjectedProps } from './lib/types';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,9 +1,9 @@
-import type { Config, Props, Options } from './types';
+import type { Config, CallbackProps, Options } from './types';
 
 export const defaultOptions: Options = {};
 export const defaultConfig: Config = { disconnectOnLeave: false };
 export const noop = () => {};
-export const defaultProps: Props = {
+export const defaultProps: CallbackProps = {
   onEnterViewport: noop,
   onLeaveViewport: noop,
 };

--- a/src/lib/handleViewport.tsx
+++ b/src/lib/handleViewport.tsx
@@ -4,7 +4,7 @@ import hoistNonReactStatic from 'hoist-non-react-statics';
 import type {
   CallbackProps,
   Config,
-  InjectedProps,
+  InjectedViewportProps,
   Options,
 } from './types';
 import useInViewport from './useInViewport';
@@ -22,7 +22,10 @@ const isReactComponent = (Component: React.ComponentClass) => {
   return Component.prototype && Component.prototype.isReactComponent;
 };
 
-function handleViewport<TElement extends HTMLElement, TProps extends InjectedProps<TElement>>(
+function handleViewport<
+  TElement extends HTMLElement,
+  TProps extends InjectedViewportProps<TElement>,
+>(
   TargetComponent: React.ComponentType<TProps>,
   options: Options = defaultOptions,
   config: Config = defaultConfig,
@@ -43,7 +46,7 @@ function handleViewport<TElement extends HTMLElement, TProps extends InjectedPro
     onEnterViewport = noop,
     onLeaveViewport = noop,
     ...restProps
-  }: Omit<TProps, keyof InjectedProps<TElement>> & CallbackProps) {
+  }: Omit<TProps, keyof InjectedViewportProps<TElement>> & CallbackProps) {
     const node = useRef<TElement>();
     const { inViewport, enterCount, leaveCount } = useInViewport(
       node,

--- a/src/lib/handleViewport.tsx
+++ b/src/lib/handleViewport.tsx
@@ -1,7 +1,12 @@
 import { useRef, forwardRef } from 'react';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 
-import type { Config, Props, Options } from './types';
+import type {
+  CallbackProps,
+  Config,
+  InjectedProps,
+  Options,
+} from './types';
 import useInViewport from './useInViewport';
 
 import { noop, defaultOptions, defaultConfig } from './constants';
@@ -17,52 +22,29 @@ const isReactComponent = (Component: React.ComponentClass) => {
   return Component.prototype && Component.prototype.isReactComponent;
 };
 
-type InjectedProps = {
-  enterCount: number;
-  inViewport: boolean;
-  leaveCount: number;
-};
-
-type RefProps = React.PropsWithRef<{
-  forwardedRef?: React.ForwardedRef<any>;
-}>;
-
-type OmittedProps = 'onEnterViewport' | 'onLeaveViewport';
-type RestPropsRef = Omit<Props, OmittedProps>;
-
-function handleViewport<P extends Props>(
-  TargetComponent: React.ElementType | React.ComponentClass<P>,
+function handleViewport<TElement extends HTMLElement, TProps extends InjectedProps<TElement>>(
+  TargetComponent: React.ComponentType<TProps>,
   options: Options = defaultOptions,
   config: Config = defaultConfig,
 ) {
-  const ForwardedRefComponent = forwardRef<
-  any,
-  InjectedProps & RefProps & RestPropsRef
-  >((props, ref) => {
-    const refProps: RefProps = {
+  const ForwardedRefComponent = forwardRef<TElement, TProps>((props, ref) => {
+    const refProps = {
       forwardedRef: ref,
       // pass both ref/forwardedRef for class component for backward compatibility
-      ...(isReactComponent(TargetComponent as React.ComponentClass<P>)
+      ...(isReactComponent(TargetComponent as React.ComponentClass<TProps>)
       && !isFunctionalComponent(TargetComponent)
-        ? {
-          ref,
-        }
+        ? { ref }
         : {}),
     };
-    return (
-      <TargetComponent
-        {...(props as RestPropsRef)}
-        {...(refProps as RefProps)}
-      />
-    );
+    return <TargetComponent {...props} {...refProps} />;
   });
 
   function InViewport({
     onEnterViewport = noop,
     onLeaveViewport = noop,
     ...restProps
-  }) {
-    const node = useRef<any>();
+  }: Omit<TProps, keyof InjectedProps<TElement>> & CallbackProps) {
+    const node = useRef<TElement>();
     const { inViewport, enterCount, leaveCount } = useInViewport(
       node,
       options,
@@ -73,14 +55,15 @@ function handleViewport<P extends Props>(
       },
     );
 
-    const injectedProps: InjectedProps = {
+    const props = {
+      ...restProps,
       inViewport,
       enterCount,
       leaveCount,
-    };
+    } as React.PropsWithoutRef<TProps>;
 
     return (
-      <ForwardedRefComponent {...restProps} {...injectedProps} ref={node} />
+      <ForwardedRefComponent {...props} ref={node} />
     );
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,10 +2,16 @@ export type Config = {
   disconnectOnLeave?: boolean;
 };
 
-export type Props = {
+export type InjectedProps<TElement extends HTMLElement = HTMLElement> = {
+  inViewport: boolean;
+  enterCount: number;
+  leaveCount: number;
+  forwardedRef: React.RefObject<TElement>;
+};
+
+export type CallbackProps = {
   onEnterViewport?: () => void;
   onLeaveViewport?: () => void;
-  [key: string]: any;
 };
 
 export type Options = IntersectionObserverInit;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@ export type Config = {
   disconnectOnLeave?: boolean;
 };
 
-export type InjectedProps<TElement extends HTMLElement = HTMLElement> = {
+export type InjectedViewportProps<TElement extends HTMLElement = HTMLElement> = {
   inViewport: boolean;
   enterCount: number;
   leaveCount: number;

--- a/src/lib/useInViewport.tsx
+++ b/src/lib/useInViewport.tsx
@@ -5,13 +5,13 @@ import { findDOMNode } from 'react-dom';
 
 import { defaultOptions, defaultConfig, defaultProps } from './constants';
 
-import type { Config, Props, Options } from './types';
+import type { Config, CallbackProps, Options } from './types';
 
 const useInViewport = (
   target: React.RefObject<HTMLElement>,
   options: Options = defaultOptions,
   config : Config = defaultConfig,
-  props: Props = defaultProps,
+  props: CallbackProps = defaultProps,
 ) => {
   const { onEnterViewport, onLeaveViewport } = props;
   const [, forceUpdate] = useState();

--- a/src/stories/chapters/enterCallback.stories.tsx
+++ b/src/stories/chapters/enterCallback.stories.tsx
@@ -43,7 +43,6 @@ export default {
 export function ClassBaseComponent() {
   return (
     <ViewportBlock
-      className="card"
       onEnterViewport={() => action('callback')('onEnterViewport')}
       onLeaveViewport={() => action('callback')('onLeaveViewport')}
     />

--- a/src/stories/common/Iframe.tsx
+++ b/src/stories/common/Iframe.tsx
@@ -2,9 +2,9 @@ import React, { PureComponent } from 'react';
 import AspectRatio from 'react-aspect-ratio';
 
 import { handleViewport } from '../../index';
-import type { InjectedProps } from '../../lib/types';
+import type { InjectedViewportProps } from '../../lib/types';
 
-type IframeProps = InjectedProps & {
+type IframeProps = InjectedViewportProps & {
   src: string;
   ratio: string;
 };

--- a/src/stories/common/Iframe.tsx
+++ b/src/stories/common/Iframe.tsx
@@ -2,9 +2,15 @@ import React, { PureComponent } from 'react';
 import AspectRatio from 'react-aspect-ratio';
 
 import { handleViewport } from '../../index';
+import type { InjectedProps } from '../../lib/types';
+
+type IframeProps = InjectedProps & {
+  src: string;
+  ratio: string;
+};
 
 class Iframe extends PureComponent<
-{ src: string; ratio: string },
+IframeProps,
 { loaded: boolean }
 > {
   constructor(props) {

--- a/src/stories/common/IframeFunctional.tsx
+++ b/src/stories/common/IframeFunctional.tsx
@@ -2,9 +2,9 @@ import React, { memo, useEffect, useState } from 'react';
 import AspectRatio from 'react-aspect-ratio';
 
 import { handleViewport } from '../../index';
-import type { InjectedProps } from '../../lib/types';
+import type { InjectedViewportProps } from '../../lib/types';
 
-type IframeFunctionalProps = InjectedProps<HTMLDivElement> & {
+type IframeFunctionalProps = InjectedViewportProps<HTMLDivElement> & {
   src: string;
   ratio: string;
 };

--- a/src/stories/common/IframeFunctional.tsx
+++ b/src/stories/common/IframeFunctional.tsx
@@ -2,8 +2,14 @@ import React, { memo, useEffect, useState } from 'react';
 import AspectRatio from 'react-aspect-ratio';
 
 import { handleViewport } from '../../index';
+import type { InjectedProps } from '../../lib/types';
 
-function IframeFunctional(props) {
+type IframeFunctionalProps = InjectedProps<HTMLDivElement> & {
+  src: string;
+  ratio: string;
+};
+
+function IframeFunctional(props: IframeFunctionalProps) {
   const {
     inViewport, src, ratio, forwardedRef,
   } = props;
@@ -27,6 +33,8 @@ function IframeFunctional(props) {
     <AspectRatio
       ratio={ratio}
       style={{ marginBottom: '200px', backgroundColor: 'rgba(0,0,0,.12)' }}
+      // @ts-expect-error
+      // TODO: fix upstream types in react-aspect-ratio to support ref
       ref={forwardedRef}
     >
       <Component {...componentProps} />

--- a/src/stories/common/Image.tsx
+++ b/src/stories/common/Image.tsx
@@ -3,11 +3,11 @@ import AspectRatio from 'react-aspect-ratio';
 
 import { INIT, LOADING, LOADED } from './constants';
 import { handleViewport } from '../../index';
-import type { InjectedProps } from '../../lib/types';
+import type { InjectedViewportProps } from '../../lib/types';
 
 const DUMMY_IMAGE_SRC = 'https://www.gstatic.com/psa/static/1.gif';
 
-type ImageObjectProps = InjectedProps & {
+type ImageObjectProps = InjectedViewportProps & {
   src: string;
   ratio: string;
 };

--- a/src/stories/common/Image.tsx
+++ b/src/stories/common/Image.tsx
@@ -3,11 +3,17 @@ import AspectRatio from 'react-aspect-ratio';
 
 import { INIT, LOADING, LOADED } from './constants';
 import { handleViewport } from '../../index';
+import type { InjectedProps } from '../../lib/types';
 
 const DUMMY_IMAGE_SRC = 'https://www.gstatic.com/psa/static/1.gif';
 
+type ImageObjectProps = InjectedProps & {
+  src: string;
+  ratio: string;
+};
+
 class ImageObject extends PureComponent<
-{ inViewport: boolean; src: string; ratio: string },
+ImageObjectProps,
 { status: number; src: string }
 > {
   // eslint-disable-line

--- a/src/stories/common/ImageFunctional.tsx
+++ b/src/stories/common/ImageFunctional.tsx
@@ -3,10 +3,16 @@ import AspectRatio from 'react-aspect-ratio';
 
 import { handleViewport } from '../../index';
 import { INIT, LOADING, LOADED } from './constants';
+import type { InjectedProps } from '../../lib/types';
 
 const DUMMY_IMAGE_SRC = 'https://www.gstatic.com/psa/static/1.gif';
 
-function ImageObject(props) {
+type ImageObjectProps = InjectedProps<HTMLDivElement> & {
+  src: string;
+  ratio: string;
+};
+
+function ImageObject(props: ImageObjectProps) {
   const {
     src: originalSrc, ratio, forwardedRef, inViewport,
   } = props;
@@ -51,6 +57,8 @@ function ImageObject(props) {
         marginBottom: '200px',
         backgroundColor: getBackgroundColor(),
       }}
+      // @ts-expect-error
+      // TODO: fix upstream types in react-aspect-ratio to support ref
       ref={forwardedRef}
     >
       <img src={src} alt="demo" />

--- a/src/stories/common/ImageFunctional.tsx
+++ b/src/stories/common/ImageFunctional.tsx
@@ -3,11 +3,11 @@ import AspectRatio from 'react-aspect-ratio';
 
 import { handleViewport } from '../../index';
 import { INIT, LOADING, LOADED } from './constants';
-import type { InjectedProps } from '../../lib/types';
+import type { InjectedViewportProps } from '../../lib/types';
 
 const DUMMY_IMAGE_SRC = 'https://www.gstatic.com/psa/static/1.gif';
 
-type ImageObjectProps = InjectedProps<HTMLDivElement> & {
+type ImageObjectProps = InjectedViewportProps<HTMLDivElement> & {
   src: string;
   ratio: string;
 };

--- a/src/stories/common/Section.tsx
+++ b/src/stories/common/Section.tsx
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 
 import { handleViewport } from '../../index';
-import type { InjectedProps } from '../../lib/types';
+import type { InjectedViewportProps } from '../../lib/types';
 
-class MySectionBlock extends PureComponent<InjectedProps> {
+class MySectionBlock extends PureComponent<InjectedViewportProps> {
   getStyle() {
     const { inViewport, enterCount } = this.props;
     const basicStyle = {

--- a/src/stories/common/Section.tsx
+++ b/src/stories/common/Section.tsx
@@ -1,12 +1,9 @@
 import React, { PureComponent } from 'react';
 
 import { handleViewport } from '../../index';
+import type { InjectedProps } from '../../lib/types';
 
-class MySectionBlock extends PureComponent<{
-  inViewport: boolean;
-  enterCount: number;
-  leaveCount: number;
-}> {
+class MySectionBlock extends PureComponent<InjectedProps> {
   getStyle() {
     const { inViewport, enterCount } = this.props;
     const basicStyle = {

--- a/src/stories/common/themeComponent.tsx
+++ b/src/stories/common/themeComponent.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { InjectedProps } from '../../lib/types';
+import { InjectedViewportProps } from '../../lib/types';
 
 export const PageTitle = memo(
   ({
@@ -48,7 +48,7 @@ export class Card extends React.PureComponent<CardProps> {
   }
 }
 
-type BlockProps = InjectedProps<HTMLDivElement>;
+type BlockProps = InjectedViewportProps<HTMLDivElement>;
 
 export function Block(props: BlockProps) {
   const {

--- a/src/stories/common/themeComponent.tsx
+++ b/src/stories/common/themeComponent.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { InjectedProps } from '../../lib/types';
 
 export const PageTitle = memo(
   ({
@@ -26,17 +27,18 @@ export const PageTitle = memo(
 );
 PageTitle.displayName = 'PageTitle';
 
-export class Card extends React.PureComponent<{
+type CardProps = {
   titleText: string;
   contentNode: React.ReactNode;
-  forwardedRef?: React.Ref<any> | undefined;
-}> {
+};
+
+export class Card extends React.PureComponent<CardProps> {
   static displayName = 'Card';
 
   render() {
-    const { titleText, contentNode, forwardedRef } = this.props;
+    const { titleText, contentNode } = this.props;
     return (
-      <div className="card" ref={forwardedRef}>
+      <div className="card">
         <div className="card__head">
           <h3 className="card__title">{titleText}</h3>
         </div>
@@ -46,7 +48,9 @@ export class Card extends React.PureComponent<{
   }
 }
 
-export function Block(props) {
+type BlockProps = InjectedProps<HTMLDivElement>;
+
+export function Block(props: BlockProps) {
   const {
     inViewport, enterCount, leaveCount, forwardedRef,
   } = props;


### PR DESCRIPTION
👋 when using this library with TypeScript, I've run into a subtle bug regarding prop types of input components to `handleViewport`.

## Rationale

Consider the following case ([CodeSandbox repl here if it's easier](https://codesandbox.io/s/react-in-viewport-injected-props-bug-uqn5ou)):
```tsx
import handleViewport from "react-in-viewport";

type SomeComponentProps = {
  style?: React.CSSProperties;
  children: React.ReactNode;
};

const SomeComponent = (props: SomeComponentProps) => {
  return <div {...props} />;
};

const SomeComponentWithViewport = handleViewport(SomeComponent);

const App = () => {
  return (
    <SomeComponentWithViewport style={{ color: "blue" }}>
      some content
    </SomeComponentWithViewport>
  );
};
```

`SomeComponent`'s props are defined in a way where it's okay to blindly spread incoming props, as they're all compatible with the underlying `div` element. However, wrapping this component with `handleViewport` has the subtle behavior that rendered `SomeComponent` elements will now receive [additional "injected" props](https://github.com/roderickhsiao/react-in-viewport#props-passed-down-by-hoc-to-your-component). When passed to the `div`, this (correctly) results in some warnings from React:
```
index.js:27 Warning: React does not recognize the `inViewport` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `inviewport` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at div
    at SomeComponent
    at InViewport (https://uqn5ou.csb.app/node_modules/react-in-viewport/dist/es/lib/handleViewport.js:37:9)
    at App
i.<computed> @ index.js:27
index.js:27 Warning: React does not recognize the `enterCount` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `entercount` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at div
    at SomeComponent
    at InViewport (https://uqn5ou.csb.app/node_modules/react-in-viewport/dist/es/lib/handleViewport.js:37:9)
    at App
i.<computed> @ index.js:27
index.js:27 Warning: React does not recognize the `leaveCount` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `leavecount` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at div
    at SomeComponent
    at InViewport (https://uqn5ou.csb.app/node_modules/react-in-viewport/dist/es/lib/handleViewport.js:37:9)
    at App
i.<computed> @ index.js:27
index.js:27 Warning: React does not recognize the `forwardedRef` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `forwardedref` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at div
    at SomeComponent
    at InViewport (https://uqn5ou.csb.app/node_modules/react-in-viewport/dist/es/lib/handleViewport.js:37:9)
    at App
```

Ideally, components passed to the HOC should be prepared for these props - for example, in the case of `SomeComponent`, it could selectively not pass those to the `div`:
```tsx
type SomeComponentProps = {
  style?: React.CSSProperties;
  children: React.ReactNode;
  inViewport: boolean;
  enterCount: number;
  leaveCount: number;
  forwardedRef: React.RefObject<HTMLElement>;
};

const SomeComponent = ({
  inViewport,
  enterCount,
  leaveCount,
  forwardedRef,
  ...rest
}: SomeComponentProps) => {
  return <div {...rest} />;
};
```

## Proposed fix

This PR updates the type signature of `handleViewport` to enforce that the props of input components include the four "injected" props. By doing so, components which aren't prepared to accept these props are caught at the static type level right when they're passed to the HOC.

This does come with the cost of needing to annotate all HOC input components with these types. Though I'd argue this is a good thing, I've also created + exported an `InjectedProps` type to easily apply these to prop definitions rather than needing to define manually:
```tsx
import handleViewport, { type InjectedProps } from 'react-in-viewport';

type SomeComponentProps = InjectedProps & {
  style?: React.CSSProperties;
  children: React.ReactNode;
};

const SomeComponent = ({
  inViewport,
  enterCount,
  leaveCount,
  forwardedRef,
  ...rest
}: SomeComponentProps) => {
  return <div {...rest} />;
};
```

## `forwardedRef` type

`forwardedRef` is a bit of an odd case - despite some components never using refs, it's still passed to HOC-wrapped components and thus needs a type with the above fix. Within the `InjectedProps` definition, I've left it as a generic `HTMLElement` by default:
```ts
export type InjectedProps<TElement extends HTMLElement = HTMLElement> = {
  inViewport: boolean;
  enterCount: number;
  leaveCount: number;
  forwardedRef: React.RefObject<TElement>;
};
```

However, consumers can override this if desired:
```tsx
type SomeComponentProps = InjectedProps<HTMLDivElement> & {
  style?: React.CSSProperties;
  children: React.ReactNode;
};

const SomeComponent = ({
  inViewport,
  enterCount,
  leaveCount,
  forwardedRef,
  ...rest
}: SomeComponentProps) => {
  return <div ref={forwardedRef} {...rest} />;
};
```

## Returned component prop type

As an added bonus, this fix also correctly defines the prop types of output components from `handleViewport`. Previously, these were fairly ambiguous even if the input component was properly defined:

![before](https://user-images.githubusercontent.com/24602724/229379642-f64cb5b2-d35f-4ad6-b69e-147d55507b19.png)

Now, thanks to the `TProps` generic, these can be passed through (omitting any injected props):

![after](https://user-images.githubusercontent.com/24602724/229379651-c0931f91-4d92-4fca-9b22-b71f5f4e35c9.png)
